### PR TITLE
cleanup the systemroot helper a bit

### DIFF
--- a/libraries/filesystem_helpers.rb
+++ b/libraries/filesystem_helpers.rb
@@ -19,25 +19,17 @@
 
 module ResourceDevelopment
   module FilesystemHelpers
+
+    # Return the windows %SystemRoot% registry entry.
     #
-    # Define the methods that you would like to assist the work you do in recipes,
-    # resources, or templates.
+    # @return [String]
     #
-    # def my_helper_method
-    #   # help method implementation
-    # end
-    def system_root?
-      sysroot = ''
-      if windows?
-        values = registry_get_values('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion')
-        values.each do |reg_key|
-          next unless reg_key[:name] == 'SystemRoot'
-          sysroot = reg_key[:value]
-        end
-      else
-        sysroot = '/'
-      end
-      sysroot
+    def system_root
+      return '/' unless windows?
+
+      values = registry_get_values('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion')
+      key = values.find { |k| k[:name] == 'SystemRoot' }
+      key[:value]
     end
   end
 end


### PR DESCRIPTION
- the '?' method ending in ruby is conventionally reserved for methods that
  return a bool, so drop that.

- do the early return guard clause to clean up the non-windows case.

- Enumerable#find can help clean up the windows case

- add some YARD docs for the method

you can even delete another line and call [:value] directly on the
same line as the find and have that returned - and not create the 'key'
variable - but that started to read too 'tricky' for me.

if you only care about recent-ish chef-14/15/16 (possibly later chef-13
as well, i can't recall exactly when it was fixed) you can also just do:

Chef::DSL::Universal.include ::ResourceDevelopment::FilesystemHelpers

instead of the all three of the Resource/Recipe/Node lines (and you're
probably missing Chef::Provider in that list)

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>